### PR TITLE
refactor: rename DomainWordToRetrievedWord to WordToRetrievedWord for clarity

### DIFF
--- a/internal/adapter/delivery/http/mapper/word.go
+++ b/internal/adapter/delivery/http/mapper/word.go
@@ -5,7 +5,7 @@ import (
 	"github.com/joqd/ruskee/internal/core/domain"
 )
 
-func DomainWordToRetrievedWord(word *domain.Word) *response.RetrievedWord {
+func WordToRetrievedWord(word *domain.Word) *response.RetrievedWord {
 	return &response.RetrievedWord{
 		ID:       word.ID,
 		Bare:     word.Bare,

--- a/internal/adapter/delivery/http/v1/word.go
+++ b/internal/adapter/delivery/http/v1/word.go
@@ -54,6 +54,6 @@ func (w *wordHTTP) GetByID(c *gin.Context) {
 		return
 	}
 
-	retrievedWord := mapper.DomainWordToRetrievedWord(word)
+	retrievedWord := mapper.WordToRetrievedWord(word)
 	response.SuccessResponse(c, http.StatusOK, retrievedWord)
 }


### PR DESCRIPTION
rename http/mapper `DomainWordToRetrievedWord` to `WordToRetrievedWord`.